### PR TITLE
Fix interpolator

### DIFF
--- a/arm-wt-22k/lib_src/eas_wtsynth.c
+++ b/arm-wt-22k/lib_src/eas_wtsynth.c
@@ -28,6 +28,7 @@
 */
 
 // includes
+#define LOG_TAG "SYNTH"
 #include "log/log.h"
 #include <cutils/log.h>
 
@@ -557,6 +558,14 @@ static EAS_BOOL WT_UpdateVoice (S_VOICE_MGR *pVoiceMgr, S_SYNTH *pSynth, S_SYNTH
     else
         temp += (pVoice->note + pSynth->globalTranspose) * 100;
     intFrame.frame.phaseIncrement = WT_UpdatePhaseInc(pWTVoice, pArt, pChannel, temp);
+    temp = pWTVoice->loopEnd - pWTVoice->loopStart;
+    if (temp != 0) {
+        temp = temp << NUM_PHASE_FRAC_BITS;
+        if (intFrame.frame.phaseIncrement > temp) {
+            ALOGW("%p phaseIncrement=%d", pWTVoice, (int)intFrame.frame.phaseIncrement);
+            intFrame.frame.phaseIncrement %= temp;
+        }
+    }
 
     /* call into engine to generate samples */
     intFrame.pAudioBuffer = pVoiceMgr->voiceBuffer;


### PR DESCRIPTION
If the phase increment was larger than the loop size, the interpolator
would read further and further outside the sample, eventually segfaulting.

Bug: 38342499
Test: manual
Change-Id: I0e70d037e61fdeffdbd49460caa692e9781cc511
(cherry picked from commit d19edc9c090d64926469463991ca7e86c73368fa)